### PR TITLE
Fix player controls spacing and sizing

### DIFF
--- a/app/src/main/kotlin/com/hyperion/ui/component/PlayerControls.kt
+++ b/app/src/main/kotlin/com/hyperion/ui/component/PlayerControls.kt
@@ -45,26 +45,30 @@ fun PlayerControls(
 
         Row(
             modifier = Modifier.align(Alignment.Center),
-            horizontalArrangement = Arrangement.spacedBy(2.dp),
+            horizontalArrangement = Arrangement.spacedBy(40.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             IconButton(onClick = onSkipPrevious) {
                 Icon(
+                    modifier = Modifier.size(30.dp),
                     imageVector = Icons.Default.SkipPrevious,
                     contentDescription = stringResource(R.string.skip_previous)
                 )
             }
 
-            IconButton(onClick = onClickPlayPause) {
+            IconButton(
+                modifier = Modifier.size(64.dp),
+                onClick = onClickPlayPause
+            ) {
                 if (isPlaying) {
                     Icon(
-                        modifier = Modifier.size(70.dp),
+                        modifier = Modifier.size(50.dp),
                         imageVector = Icons.Default.Pause,
                         contentDescription = stringResource(R.string.pause)
                     )
                 } else {
                     Icon(
-                        modifier = Modifier.size(70.dp),
+                        modifier = Modifier.size(50.dp),
                         imageVector = Icons.Default.PlayArrow,
                         contentDescription = stringResource(R.string.play)
                     )
@@ -73,6 +77,7 @@ fun PlayerControls(
 
             IconButton(onClick = onSkipNext) {
                 Icon(
+                    modifier = Modifier.size(30.dp),
                     imageVector = Icons.Default.SkipNext,
                     contentDescription = stringResource(R.string.skip_next)
                 )


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/31113245/186021399-a0e4e4b9-8271-4188-8224-17c666518c7a.png)
After:
![image](https://user-images.githubusercontent.com/31113245/186021455-cad8858b-70da-4cfb-b38b-318b4dad05ef.png)

Motivation behind this: 
![image](https://user-images.githubusercontent.com/31113245/186021492-f212ddca-725a-46d8-a9b7-c0b395cfd6a6.png)
![image](https://user-images.githubusercontent.com/31113245/186021532-8230ef17-e163-4fa4-9197-6494eb0d848b.png)
