### PR TITLE
fix: apk packaging excludes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,10 +37,23 @@ android {
 
     packagingOptions {
         resources {
-            excludes += "/**/*.version"
-            excludes += "/kotlin-tooling-metadata.json"
+            // Reflection symbol list (https://stackoverflow.com/a/41073782/13964629)
+            excludes += "/**/*.kotlin_builtins"
+
+            // okhttp3 is used by some lib (no cookies so publicsuffixes.gz can be dropped)
             excludes += "/okhttp3/**"
-            excludes += "/DebugProbesKt.bin"
+        }
+    }
+
+    androidComponents {
+        onVariants(selector().withBuildType("release")) {
+            it.packaging.resources.excludes.apply {
+                // Debug metadata
+                add("/**/*.version")
+                add("/kotlin-tooling-metadata.json")
+                // Kotlin debugging (https://github.com/Kotlin/kotlinx.coroutines/issues/2274)
+                add("/DebugProbesKt.bin")
+            }
         }
     }
 


### PR DESCRIPTION
Currently the packaging options excludes crucial information for debugging on debug build, fix